### PR TITLE
add metadata as json file for machine readability

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include repodata_tools/metadata.json

--- a/repodata_tools/metadata.json
+++ b/repodata_tools/metadata.json
@@ -1,0 +1,18 @@
+{
+    "subdirs": ["linux-64", "osx-64", "win-64", "noarch", "linux-aarch64", "linux-ppc64le", "osx-arm64"],
+    "unindexable": [
+        "linux-64/pyside2-2.0.0~alpha0-py27_0.tar.bz2",
+        "linux-64/pyside2-2.0.0~alpha0-py35_0.tar.bz2",
+        "linux-64/pyside2-2.0.0~alpha0-py36_0.tar.bz2",
+        "osx-64/pyside2-2.0.0~alpha0-py27_0.tar.bz2",
+        "osx-64/pyside2-2.0.0~alpha0-py35_0.tar.bz2",
+        "osx-64/pyside2-2.0.0~alpha0-py36_0.tar.bz2"
+    ],
+    "undistributable": [
+        "cudatoolkit",
+        "cudnn",
+        "cutensor",
+        "cusparselt",
+        "msmpi"
+    ]
+}

--- a/repodata_tools/metadata.py
+++ b/repodata_tools/metadata.py
@@ -8,7 +8,7 @@ import os
 
 HERE = os.path.dirname(os.path.abspath(__file__))
 
-with open(os.path.join(HERE, "metadata.json", "w")) as f:
+with open(os.path.join(HERE, "metadata.json"), "r") as f:
     metadata = json.load(f)
 
 CONDA_FORGE_SUBIDRS = CONDA_FORGE_SUBDIRS = metadata["subdirs"]

--- a/repodata_tools/metadata.py
+++ b/repodata_tools/metadata.py
@@ -3,30 +3,20 @@
 # - we use a mod operator to distribute them over tasks
 # - they are ordered so that mod by 4 puts the biggest subdirs on separate tasks
 import hashlib
+import json
+import os
 
-CONDA_FORGE_SUBIDRS = [
-    "linux-64", "osx-64", "win-64", "noarch",
-    "linux-aarch64", "linux-ppc64le", "osx-arm64"
-]
+HERE = os.path.dirname(os.path.abspath(__file__))
 
+with open(os.path.join(HERE, "metadata.json", "w")) as f:
+    metadata = json.load(f)
+
+CONDA_FORGE_SUBIDRS = CONDA_FORGE_SUBDIRS = metadata["subdirs"]
 
 # these packages cannot be indexed
-UNINDEXABLE = [
-    "linux-64/pyside2-2.0.0~alpha0-py27_0.tar.bz2",
-    "linux-64/pyside2-2.0.0~alpha0-py35_0.tar.bz2",
-    "linux-64/pyside2-2.0.0~alpha0-py36_0.tar.bz2",
-    "osx-64/pyside2-2.0.0~alpha0-py27_0.tar.bz2",
-    "osx-64/pyside2-2.0.0~alpha0-py35_0.tar.bz2",
-    "osx-64/pyside2-2.0.0~alpha0-py36_0.tar.bz2",
-]
+UNINDEXABLE = metadata["unindexable"]
 
-UNDISTRIBUTABLE = [
-    "cudatoolkit",
-    "cudnn",
-    "cutensor",
-    "cusparselt",
-    "msmpi",
-]
+UNDISTRIBUTABLE = metadata["undistributable"]
 
 UNDISTRIBUTABLE_HASH = hashlib.sha256(
     "".join(sorted(UNDISTRIBUTABLE)).encode("utf-8")


### PR DESCRIPTION
Hey @beckermr this PR adds the metadata as a json file so that we could read it more easily from other places (e.g. quetz ...) by accessing some `raw.github.com/.../metadata.json` url